### PR TITLE
Fix slug encoding bug

### DIFF
--- a/app/pages/blog/[slug].vue
+++ b/app/pages/blog/[slug].vue
@@ -2,7 +2,11 @@
 const route = useRoute()
 const slug = route.params.slug
 
-const { data, pending, error } = await useFetch(`/api/post/${slug}`)
+// Use encodeURIComponent in case the slug contains characters that
+// need to be safely encoded when used in a URL
+const { data, pending, error } = await useFetch(
+  `/api/post/${encodeURIComponent(slug)}`
+)
 
 // A helper to format the date
 const formattedDate = computed(() => {


### PR DESCRIPTION
## Summary
- encode slug when fetching blog posts

## Testing
- `npm run build` *(fails: nuxt not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883c1486230832bb6c544ec898dffbe