### PR TITLE
Fix blog index path comment

### DIFF
--- a/app/pages/blog/index.vue
+++ b/app/pages/blog/index.vue
@@ -1,4 +1,4 @@
-// app/pages/blog.vue
+// app/pages/blog/index.vue
 <script setup lang="ts">
 const { data } = await useFetch('/api/posts')
 </script>


### PR DESCRIPTION
## Summary
- fix the path comment in `app/pages/blog/index.vue`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6883c3ef8170832ba9ba4c09e4c469e1