### PR TITLE
Fix GraphQL endpoint naming

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -4,7 +4,7 @@ export default defineNuxtConfig({
 
   runtimeConfig: {
     public: {
-      wpGraphqlEndpoint: 'https://cms.digifynn.com/graphql'
+      wpGraphQLEndpoint: 'https://cms.digifynn.com/graphql'
     }
   },
 

--- a/server/api/post/[slug].get.ts
+++ b/server/api/post/[slug].get.ts
@@ -25,7 +25,7 @@ const QUERY = gql`
 
 export default defineEventHandler(async (event) => {
   const slug = getRouterParam(event, 'slug')
-  const endpoint = useRuntimeConfig().public.wpGraphqlEndpoint
+  const endpoint = useRuntimeConfig().public.wpGraphQLEndpoint
   const variables = { slug }
 
   return request(endpoint, QUERY, variables)

--- a/server/api/posts.get.ts
+++ b/server/api/posts.get.ts
@@ -15,6 +15,6 @@ const QUERY = gql`
 `
 
 export default defineEventHandler(async () => {
-  const endpoint = useRuntimeConfig().public.wpGraphqlEndpoint
+  const endpoint = useRuntimeConfig().public.wpGraphQLEndpoint
   return request(endpoint, QUERY)
 })


### PR DESCRIPTION
## Summary
- rename wpGraphqlEndpoint property to wpGraphQLEndpoint in Nuxt config
- update server API handlers to use the new runtime config

## Testing
- `npm run build` *(fails: nuxt not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883c3eec068832b8c118d6b73ca317d