### PR TITLE
Add Vitest setup and posts API test

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,12 +7,16 @@
     "dev": "nuxt dev",
     "generate": "nuxt generate",
     "preview": "nuxt preview",
-    "postinstall": "nuxt prepare"
+    "postinstall": "nuxt prepare",
+    "test": "vitest"
   },
   "dependencies": {
     "graphql-request": "^7.2.0",
     "nuxt": "^4.0.1",
     "vue": "^3.5.17",
     "vue-router": "^4.5.1"
+  },
+  "devDependencies": {
+    "vitest": "^1.5.0"
   }
 }

--- a/tests/api/posts.spec.ts
+++ b/tests/api/posts.spec.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from 'vitest'
+
+const mockResponse = {
+  posts: {
+    nodes: [
+      {
+        id: '1',
+        title: 'Test Post',
+        content: 'Content',
+        date: '2024-01-01',
+        slug: 'test-post'
+      }
+    ]
+  }
+}
+
+vi.mock('graphql-request', () => ({
+  request: vi.fn().mockResolvedValue(mockResponse),
+  gql: (q: TemplateStringsArray) => q[0]
+}))
+
+// Provide Nuxt runtime helpers
+;(global as any).defineEventHandler = (fn: any) => fn
+;(global as any).useRuntimeConfig = () => ({
+  public: { wpGraphqlEndpoint: 'http://example.com/graphql' }
+})
+
+describe('GET /api/posts', () => {
+  it('returns list with expected structure', async () => {
+    const { default: handler } = await import('../../server/api/posts.get')
+    const data = await handler()
+
+    expect(Array.isArray(data.posts.nodes)).toBe(true)
+    expect(data.posts.nodes[0]).toEqual(
+      expect.objectContaining({
+        id: expect.any(String),
+        title: expect.any(String),
+        content: expect.any(String),
+        date: expect.any(String),
+        slug: expect.any(String)
+      })
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- add `vitest` as a dev dependency
- expose `test` script
- configure `tests` folder with a posts API test

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883c3efdf40832b9515e606d7482952