### PR TITLE
Update blog author display

### DIFF
--- a/app/pages/blog/[slug].vue
+++ b/app/pages/blog/[slug].vue
@@ -30,7 +30,7 @@ const formattedDate = computed(() => {
         </div>
         <h1 class="post-title" v-html="data.post.title"></h1>
         <div class="post-meta">
-          <span>نویسنده: {{ data.post.author.node.name }}</span>
+          <span>نویسنده: دیجی‌فاین</span>
           <span> | </span>
           <span>{{ formattedDate }}</span>
         </div>


### PR DESCRIPTION
## Summary
- set blog posts to always display the author name as دیجی‌فاین

## Testing
- `npm run build` *(fails: no npm packages installed)*

------
https://chatgpt.com/codex/tasks/task_e_6883c5d95fb4832bacd8cf84f6657897