### PR TITLE
Add minimal footer component

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -1,10 +1,12 @@
 <template>
   <div>
     <TheHeader />
-    
+
     <main class="main-content">
       <NuxtPage />
     </main>
+
+    <TheFooter />
   </div>
 </template>
 

--- a/components/TheFooter.vue
+++ b/components/TheFooter.vue
@@ -1,0 +1,16 @@
+<template>
+  <footer class="main-footer">
+    <p>&copy; 2024 DigiFynn</p>
+  </footer>
+</template>
+
+<style scoped>
+.main-footer {
+  font-family: 'Vazirmatn', sans-serif;
+  background-color: #f2f2f2;
+  color: #666;
+  text-align: center;
+  padding: 1rem;
+  font-size: 0.9rem;
+}
+</style>

--- a/tests/components/footer.spec.ts
+++ b/tests/components/footer.spec.ts
@@ -1,0 +1,8 @@
+import { describe, it, expect } from 'vitest'
+import Footer from '../../components/TheFooter.vue'
+
+describe('TheFooter component', () => {
+  it('is defined', () => {
+    expect(Footer).toBeTruthy()
+  })
+})


### PR DESCRIPTION
## Summary
- add a simple `TheFooter` component with basic styling
- render the footer in the main app layout
- add a very small test to ensure the footer component is defined

## Testing
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883ca3e2a9c832bb6e69e7bf471cc25